### PR TITLE
Support boot2docker (and its tcp + ssl thing)

### DIFF
--- a/hoosegow.gemspec
+++ b/hoosegow.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec',      '>= 2.14.1', '~> 2.14'
   s.add_runtime_dependency     'msgpack',    '>= 0.5.6',  '~> 0.5'
   s.add_runtime_dependency     'yajl-ruby',  '>= 1.1.0',  '~> 1.1'
-  s.add_runtime_dependency     'docker-api', '>= 1.13.6', '< 2.0'
+  s.add_runtime_dependency     'docker-api', '~> 1.15'
 end

--- a/hoosegow.gemspec
+++ b/hoosegow.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec',      '>= 2.14.1', '~> 2.14'
   s.add_runtime_dependency     'msgpack',    '>= 0.5.6',  '~> 0.5'
   s.add_runtime_dependency     'yajl-ruby',  '>= 1.1.0',  '~> 1.1'
-  s.add_runtime_dependency     'docker-api', '~> 1.15'
+  s.add_runtime_dependency     'docker-api', '~> 1.19'
 end

--- a/hoosegow.gemspec
+++ b/hoosegow.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec',      '>= 2.14.1', '~> 2.14'
   s.add_runtime_dependency     'msgpack',    '>= 0.5.6',  '~> 0.5'
   s.add_runtime_dependency     'yajl-ruby',  '>= 1.1.0',  '~> 1.1'
-  s.add_runtime_dependency     'docker-api', '~> 1.13.6'
+  s.add_runtime_dependency     'docker-api', '>= 1.13.6', '< 2.0'
 end

--- a/lib/hoosegow/docker.rb
+++ b/lib/hoosegow/docker.rb
@@ -38,7 +38,7 @@ class Hoosegow
     #           :Other - any option with a capitalized key will be passed on
     #                    to the 'create container' call. See http://docs.docker.io/en/latest/reference/api/docker_remote_api_v1.9/#create-a-container
     def initialize(options = {})
-      ::Docker.url       = docker_url options
+      set_docker_url! options
       @after_create      = options[:after_create]
       @after_start       = options[:after_start]
       @after_stop        = options[:after_stop]
@@ -168,6 +168,13 @@ class Hoosegow
     end
 
   private
+    # Private: Set the docker URL, if related options are present.
+    def set_docker_url!(options)
+      if url = docker_url(options)
+        ::Docker.url = url
+      end
+    end
+
     # Private: Get the URL to use for communicating with Docker. If a host and/or
     # port a present, a TCP socket URL will be generated. Otherwise a Unix
     # socket will be used.
@@ -184,9 +191,10 @@ class Hoosegow
         host = options[:host] || DEFAULT_HOST
         port = options[:port] || DEFAULT_PORT
         "tcp://#{host}:#{port}"
-      else
-        path = options[:socket] || DEFAULT_SOCKET
+      elsif path = options[:socket]
         "unix://#{path}"
+      else
+        nil
       end
     end
 


### PR DESCRIPTION
This branch makes it so that hoosegow can use the environment variables set by `boot2docker shellinit`. It does this by not setting `Docker.url` if no connection parameters are provided. This lets the `docker-api` gem figure out where to connect, which should be right most of the time. This branch also bumps the `docker-api` gem version: 1.15 is where it learned to use boot2docker over TLS (https://github.com/swipely/docker-api/pull/210), and 1.19 has a fix for attached containers (https://github.com/swipely/docker-api/pull/251).

cc @mastahyeti 