### PR TITLE
Docker#delete_container: rescue on "device or resource busy" error

### DIFF
--- a/lib/hoosegow/docker.rb
+++ b/lib/hoosegow/docker.rb
@@ -127,6 +127,8 @@ class Hoosegow
     def delete_container
       return unless @container
       @container.delete
+    rescue ::Docker::Error::ServerError => e
+      $stderr.puts "Docker could not delete #{@container.id}: #{e}"
     end
 
     # Public: Build a new image.

--- a/spec/hoosegow_docker_spec.rb
+++ b/spec/hoosegow_docker_spec.rb
@@ -106,4 +106,26 @@ describe Hoosegow::Docker do
       expect(docker.image_exist?("not_there")).to eq(false)
     end
   end
+
+  context "delete_container" do
+    let(:docker) { Hoosegow::Docker.new CONFIG }
+    let(:container) { Object.new }
+    before do
+      docker.instance_variable_set(:@container, container)
+      allow(container).to receive(:id).and_return("1234")
+      $old_stderr = $stderr
+      $stderr = StringIO.new
+    end
+    after do
+      $stderr = $old_stderr
+    end
+
+    it "rescues error and prints when error is raised" do
+      allow(container).to receive(:delete).
+        and_raise(::Docker::Error::ServerError, "device or resource busy")
+      docker.delete_container
+      $stderr.rewind
+      expect($stderr.read).to eql("Docker could not delete 1234: device or resource busy\n")
+    end
+  end
 end


### PR DESCRIPTION
@spraints Not really sure the best way to go about testing this change, but this should help us handle https://github.com/docker/docker/issues/9665. 

Hoosegow does automatically attempt to delete the container once the process ends. Would a better option be to `sleep 1` and try to delete again? Seems crazy but maybe that’d quell the “resource busy” errors we see.