### PR TITLE
Remove associated volumes, too

### DIFF
--- a/lib/hoosegow/docker.rb
+++ b/lib/hoosegow/docker.rb
@@ -126,7 +126,7 @@ class Hoosegow
     # Returns response body or nil if no container was started.
     def delete_container
       return unless @container
-      @container.delete
+      @container.delete :v => 1
     rescue ::Docker::Error::ServerError => e
       $stderr.puts "Docker could not delete #{@container.id}: #{e}"
     end


### PR DESCRIPTION
Docker's default is to leave the volumes in place when a [container is removed](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.19/#remove-a-container). Hoosegow containers are ephemeral, and any persistent data should be in a mounted volume.

With docker 1.9, mounting a directory `ro` from a different filesystem copies all of the files into the docker storage dir. The volume isn't removed when the container is removed, so we end up with tons of copies of these files that aren't going to get used anymore.

cc @parkr @mastahyeti 