### PR TITLE
Remove 'require "rake"' from gemspec

### DIFF
--- a/hoosegow.gemspec
+++ b/hoosegow.gemspec
@@ -1,5 +1,3 @@
-require 'rake'
-
 Gem::Specification.new do |s|
   s.name        = 'hoosegow'
   s.version     = '1.2.4'


### PR DESCRIPTION
In Ruby 2.3.1, `rake` is not installed automatically. Therefore, loading it is impossible... Error message:

```text
+ rbenv exec bundle install --local --path .bundle --no-cache --without development test

There was a LoadError while loading hoosegow.gemspec:
cannot load such file -- rake from
  /hoosegow/hoosegow.gemspec:1:in `<main>'

Does it try to require a relative path? That's been removed in Ruby 1.9.
```

/cc @spraints @mastahyeti for review