### PR TITLE
Release v1.2.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hoosegow (1.2.4)
+    hoosegow (1.2.5)
       docker-api (~> 1.19)
       msgpack (~> 0.5, >= 0.5.6)
       yajl-ruby (~> 1.1, >= 1.1.0)
@@ -9,22 +9,22 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.4)
-    docker-api (1.23.0)
+    diff-lcs (1.2.5)
+    docker-api (1.31.0)
       excon (>= 0.38.0)
       json
-    excon (0.45.4)
-    json (1.8.3)
-    msgpack (0.7.1)
-    rake (10.5.0)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.5)
-    rspec-expectations (2.14.3)
+    excon (0.52.0)
+    json (2.0.2)
+    msgpack (0.7.6)
+    rake (11.2.2)
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
       diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.3)
+    rspec-mocks (2.99.4)
     yajl-ruby (1.2.1)
 
 PLATFORMS
@@ -36,4 +36,4 @@ DEPENDENCIES
   rspec (~> 2.14, >= 2.14.1)
 
 BUNDLED WITH
-   1.10.6
+   1.12.5

--- a/hoosegow.gemspec
+++ b/hoosegow.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'hoosegow'
-  s.version     = '1.2.4'
+  s.version     = '1.2.5'
   s.summary     = "A Docker jail for ruby code"
   s.description = "Hoosegow provides an RPC layer on top of Docker containers so that you can isolate unsafe parts of your application."
   s.authors     = ["Ben Toews", "Matt Burke"]


### PR DESCRIPTION
Updated the Gemfile.lock, though it's not really necessary here. If we need to constrain gem versions, that would have to go in the gemspec.

Releases #13. /cc @spraints for 👍 