### PR TITLE
Inmate#run: rescue all Exception instead of just StandardError

### DIFF
--- a/lib/hoosegow/protocol.rb
+++ b/lib/hoosegow/protocol.rb
@@ -90,7 +90,7 @@ class Hoosegow
           nil # Don't return anything from the inmate's `yield`.
         end
         report(:return, result)
-      rescue => e
+      rescue Exception => e
         report(:raise, {:class => e.class.name, :message => e.message, :backtrace => e.backtrace})
       end
 

--- a/spec/hoosegow_spec.rb
+++ b/spec/hoosegow_spec.rb
@@ -120,7 +120,7 @@ describe Hoosegow::Protocol::Inmate do
 
   it "encodes exceptions" do
     inmate = Object.new
-    def inmate.render(s) ; raise 'boom' ; end
+    def inmate.render(s) ; raise Exception, 'boom' ; end
 
     stdin = StringIO.new(MessagePack.pack(['render', ['foobar']]))
     stdout = StringIO.new
@@ -131,7 +131,7 @@ describe Hoosegow::Protocol::Inmate do
 
     unpacked_type, unpacked_data = MessagePack.unpack(stdout.string)
     expect(unpacked_type).to eq('raise')
-    expect(unpacked_data).to include('class' => 'RuntimeError')
+    expect(unpacked_data).to include('class' => 'Exception')
     expect(unpacked_data).to include('message' => 'boom')
     expect(unpacked_data['backtrace']).to be_a(Array)
     expect(unpacked_data['backtrace'].first).to eq("#{__FILE__}:#{__LINE__ - 14}:in `render'")


### PR DESCRIPTION
This allows you to capture _all_ exceptions an inmate's method might raise.

/cc @spraints 
