### PR TITLE
Bump msgpack gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,19 +3,19 @@ PATH
   specs:
     hoosegow (1.2.5)
       docker-api (~> 1.19)
-      msgpack (~> 0.5, >= 0.5.6)
+      msgpack (~> 1.0.0)
       yajl-ruby (~> 1.1, >= 1.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    docker-api (1.31.0)
+    docker-api (1.33.2)
       excon (>= 0.38.0)
       json
-    excon (0.52.0)
-    json (2.0.2)
-    msgpack (0.7.6)
+    excon (0.55.0)
+    json (2.0.3)
+    msgpack (1.0.3)
     rake (11.2.2)
     rspec (2.99.0)
       rspec-core (~> 2.99.0)
@@ -25,7 +25,7 @@ GEM
     rspec-expectations (2.99.2)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.99.4)
-    yajl-ruby (1.2.1)
+    yajl-ruby (1.3.0)
 
 PLATFORMS
   ruby
@@ -36,4 +36,4 @@ DEPENDENCIES
   rspec (~> 2.14, >= 2.14.1)
 
 BUNDLED WITH
-   1.12.5
+   1.14.6

--- a/hoosegow.gemspec
+++ b/hoosegow.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 1.9.3"
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec',      '>= 2.14.1', '~> 2.14'
-  s.add_runtime_dependency     'msgpack',    '>= 0.5.6',  '~> 0.5'
+  s.add_runtime_dependency     'msgpack',    '~> 1.0.0'
   s.add_runtime_dependency     'yajl-ruby',  '>= 1.1.0',  '~> 1.1'
   s.add_runtime_dependency     'docker-api', '~> 1.19'
 end


### PR DESCRIPTION
The gem requires a version bump for ruby 2.4.0 support.