### PR TITLE
Update for new Docker API

### DIFF
--- a/lib/hoosegow/docker.rb
+++ b/lib/hoosegow/docker.rb
@@ -80,9 +80,11 @@ class Hoosegow
     # Returns nothing.
     def create_container(image)
       @container = ::Docker::Container.create @container_options.merge(
-        :StdinOnce => true,
-        :OpenStdin => true,
-        :Volumes   => volumes_for_create,
+        :StdinOnce  => true,
+        :OpenStdin  => true,
+        :HostConfig => {
+          :Binds    => volumes_for_bind
+        },
         :Image     => image
       )
       callback @after_create
@@ -92,7 +94,7 @@ class Hoosegow
     #
     # Returns nothing.
     def start_container
-      @container.start :Binds => volumes_for_bind
+      @container.start
       callback @after_start
     end
 
@@ -200,19 +202,7 @@ class Hoosegow
       end
     end
 
-    # Private: Generate the `Volumes` argument for creating a container.
-    #
-    # Given a hash of container_path => local_path in @volumes, generate a
-    # hash of container_path => {}.
-    def volumes_for_create
-      result = {}
-      each_volume do |container_path, local_path, permissions|
-        result[container_path] = {}
-      end
-      result
-    end
-
-    # Private: Generate the `Binds` argument for starting a container.
+    # Private: Generate the `Binds` argument for creating a container.
     #
     # Given a hash of container_path => local_path in @volumes, generate an
     # array of "local_path:container_path:rw".

--- a/spec/hoosegow_docker_spec.rb
+++ b/spec/hoosegow_docker_spec.rb
@@ -19,13 +19,11 @@ describe Hoosegow::Docker do
 
     context 'unspecified' do
       subject { described_class.new }
-      its(:volumes_for_create) { should be_empty }
       its(:volumes_for_bind) { should be_empty }
     end
 
     context 'empty' do
       let(:volumes) { {} }
-      its(:volumes_for_create) { should be_empty }
       its(:volumes_for_bind) { should be_empty }
     end
 
@@ -33,10 +31,6 @@ describe Hoosegow::Docker do
       let(:volumes) { {
         "/inside/path" => "/home/burke/data-for-container:rw",
         "/other/path" => "/etc/shared-config",
-      } }
-      its(:volumes_for_create) { should == {
-        "/inside/path" => {},
-        "/other/path" => {},
       } }
       its(:volumes_for_bind) { should == [
         "/home/burke/data-for-container:/inside/path:rw",


### PR DESCRIPTION
Update volume mounts for new docker api

Docker Engine API has deprecated passing in options when starting the container and now expects all volumes/binds to be passed in when the container is created.

This also adds a spec test to verify that volume mounts are actually active by mounting a local directory into a container then having the container create a file in that directory, and having the test verify it was successfully created.