### PR TITLE
Allow user to pass options to #build_image

### DIFF
--- a/lib/hoosegow.rb
+++ b/lib/hoosegow.rb
@@ -131,8 +131,8 @@ class Hoosegow
   # the gem.
   #
   # Returns build output text. Raises ImageBuildError if there is a problem.
-  def build_image(&block)
-    docker.build_image image_name, image_bundle.tarball, &block
+  def build_image(build_opts = {}, &block)
+    docker.build_image image_name, image_bundle.tarball, build_opts, &block
   end
 
   # Private: The name of the docker image to use. If not specified manually,

--- a/lib/hoosegow/docker.rb
+++ b/lib/hoosegow/docker.rb
@@ -139,7 +139,7 @@ class Hoosegow
     # tarfile - Tarred data for creating image. See http://docs.docker.io/en/latest/api/docker_remote_api_v1.5/#build-an-image-from-dockerfile-via-stdin
     #
     # Returns Array of build result objects from the Docker API.
-    def build_image(name, tarfile)
+    def build_image(name, tarfile, build_opts = {})
       # Setup parser to receive chunks and yield parsed JSON objects.
       ret = []
       error = nil
@@ -151,7 +151,7 @@ class Hoosegow
       end
 
       # Make API call to create image.
-      opts = {:t => name, :rm => '1'}
+      opts = {:t => name, :rm => '1'}.merge(build_opts)
       ::Docker::Image.build_from_tar StringIO.new(tarfile), opts do |chunk|
         parser << chunk
       end


### PR DESCRIPTION
This allows the user to tweak the parameters sent to the Docker API.

I'd love to be able to cache image layers, so I'd love to override `rm: 1`, for example.

This also allows clients to iterate with the Docker API as it evolves without updates to Hoosegow directly.