### PR TITLE
Update the links to Docker docs

### DIFF
--- a/docs/dispatch.md
+++ b/docs/dispatch.md
@@ -24,7 +24,7 @@ It reads the Docker response as it comes in. It demultiplexes the docker output 
 
 Docker receives an HTTP POST with a body, and returns an HTTP response with a body. The HTTP request body is treated as `STDIN`, and the response body contains `STDOUT` and `STDERR`.
 
-See [documentation for attach](http://docs.docker.io/en/latest/reference/api/docker_remote_api_v1.7/#attach-to-a-container).
+See [documentation for attach](https://docs.docker.com/engine/api/v1.40/#operation/ContainerAttach).
 
 ### bin/hoosegow
 

--- a/lib/hoosegow/docker.rb
+++ b/lib/hoosegow/docker.rb
@@ -36,7 +36,7 @@ class Hoosegow
     #                         }
     #                       `:volumes => { "/work" => "/home/localuser/work/to/do" }`
     #           :Other - any option with a capitalized key will be passed on
-    #                    to the 'create container' call. See http://docs.docker.io/en/latest/reference/api/docker_remote_api_v1.9/#create-a-container
+    #                    to the 'create container' call. See https://docs.docker.com/engine/api/v1.40/#operation/ContainerCreate
     def initialize(options = {})
       set_docker_url! options
       @after_create      = options[:after_create]
@@ -138,7 +138,7 @@ class Hoosegow
     # Public: Build a new image.
     #
     # name    - The name to give the image.
-    # tarfile - Tarred data for creating image. See http://docs.docker.io/en/latest/api/docker_remote_api_v1.5/#build-an-image-from-dockerfile-via-stdin
+    # tarfile - Tarred data for creating image. See https://docs.docker.com/engine/api/v1.40/#operation/ImageBuild
     #
     # Returns Array of build result objects from the Docker API.
     def build_image(name, tarfile)


### PR DESCRIPTION
The links currently lead to a 404 page. Closes #20.