### PR TITLE
Update rspec so that 'rake spec' works again

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     docker-api (1.34.2)
       excon (>= 0.47.0)
       multi_json
@@ -17,14 +17,18 @@ GEM
     msgpack (1.0.3)
     multi_json (1.13.1)
     rake (12.3.3)
-    rspec (2.99.0)
-      rspec-core (~> 2.99.0)
-      rspec-expectations (~> 2.99.0)
-      rspec-mocks (~> 2.99.0)
-    rspec-core (2.99.2)
-    rspec-expectations (2.99.2)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.99.4)
+    rspec (3.0.0)
+      rspec-core (~> 3.0.0)
+      rspec-expectations (~> 3.0.0)
+      rspec-mocks (~> 3.0.0)
+    rspec-core (3.0.4)
+      rspec-support (~> 3.0.0)
+    rspec-expectations (3.0.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.0.0)
+    rspec-mocks (3.0.4)
+      rspec-support (~> 3.0.0)
+    rspec-support (3.0.4)
     yajl-ruby (1.4.1)
 
 PLATFORMS
@@ -33,7 +37,7 @@ PLATFORMS
 DEPENDENCIES
   hoosegow!
   rake
-  rspec (~> 2.14, >= 2.14.1)
+  rspec (~> 3.0.0)
 
 BUNDLED WITH
    1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,18 +17,18 @@ GEM
     msgpack (1.0.3)
     multi_json (1.13.1)
     rake (12.3.3)
-    rspec (3.0.0)
-      rspec-core (~> 3.0.0)
-      rspec-expectations (~> 3.0.0)
-      rspec-mocks (~> 3.0.0)
-    rspec-core (3.0.4)
-      rspec-support (~> 3.0.0)
-    rspec-expectations (3.0.4)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.0.0)
-    rspec-mocks (3.0.4)
-      rspec-support (~> 3.0.0)
-    rspec-support (3.0.4)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.2)
     yajl-ruby (1.4.1)
 
 PLATFORMS
@@ -37,7 +37,7 @@ PLATFORMS
 DEPENDENCIES
   hoosegow!
   rake
-  rspec (~> 3.0.0)
+  rspec (~> 3.1.0)
 
 BUNDLED WITH
    1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,18 +17,19 @@ GEM
     msgpack (1.0.3)
     multi_json (1.13.1)
     rake (12.3.3)
-    rspec (3.1.0)
-      rspec-core (~> 3.1.0)
-      rspec-expectations (~> 3.1.0)
-      rspec-mocks (~> 3.1.0)
-    rspec-core (3.1.7)
-      rspec-support (~> 3.1.0)
-    rspec-expectations (3.1.2)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.3)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.1.0)
-    rspec-mocks (3.1.3)
-      rspec-support (~> 3.1.0)
-    rspec-support (3.1.2)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.2)
     yajl-ruby (1.4.1)
 
 PLATFORMS
@@ -37,7 +38,7 @@ PLATFORMS
 DEPENDENCIES
   hoosegow!
   rake
-  rspec (~> 3.1.0)
+  rspec (~> 3.2.0)
 
 BUNDLED WITH
    1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,19 +17,19 @@ GEM
     msgpack (1.0.3)
     multi_json (1.13.1)
     rake (12.3.3)
-    rspec (3.2.0)
-      rspec-core (~> 3.2.0)
-      rspec-expectations (~> 3.2.0)
-      rspec-mocks (~> 3.2.0)
-    rspec-core (3.2.3)
-      rspec-support (~> 3.2.0)
-    rspec-expectations (3.2.1)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.2)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.2.0)
-    rspec-mocks (3.2.1)
+      rspec-support (~> 3.3.0)
+    rspec-mocks (3.3.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.2.0)
-    rspec-support (3.2.2)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
     yajl-ruby (1.4.1)
 
 PLATFORMS
@@ -38,7 +38,7 @@ PLATFORMS
 DEPENDENCIES
   hoosegow!
   rake
-  rspec (~> 3.2.0)
+  rspec (~> 3.3.0)
 
 BUNDLED WITH
    1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,19 +17,19 @@ GEM
     msgpack (1.0.3)
     multi_json (1.13.1)
     rake (12.3.3)
-    rspec (3.3.0)
-      rspec-core (~> 3.3.0)
-      rspec-expectations (~> 3.3.0)
-      rspec-mocks (~> 3.3.0)
-    rspec-core (3.3.2)
-      rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-mocks (3.3.2)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-support (3.3.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
     yajl-ruby (1.4.1)
 
 PLATFORMS
@@ -38,7 +38,7 @@ PLATFORMS
 DEPENDENCIES
   hoosegow!
   rake
-  rspec (~> 3.3.0)
+  rspec (~> 3.9.0)
 
 BUNDLED WITH
    1.16.1

--- a/hoosegow.gemspec
+++ b/hoosegow.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/github/hoosegow'
   s.required_ruby_version = ">= 1.9.3"
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec',      '~> 3.1.0'
+  s.add_development_dependency 'rspec',      '~> 3.2.0'
   s.add_runtime_dependency     'msgpack',    '~> 1.0.0'
   s.add_runtime_dependency     'yajl-ruby',  '>= 1.1.0',  '~> 1.1'
   s.add_runtime_dependency     'docker-api', '~> 1.19'

--- a/hoosegow.gemspec
+++ b/hoosegow.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/github/hoosegow'
   s.required_ruby_version = ">= 1.9.3"
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec',      '~> 3.2.0'
+  s.add_development_dependency 'rspec',      '~> 3.3.0'
   s.add_runtime_dependency     'msgpack',    '~> 1.0.0'
   s.add_runtime_dependency     'yajl-ruby',  '>= 1.1.0',  '~> 1.1'
   s.add_runtime_dependency     'docker-api', '~> 1.19'

--- a/hoosegow.gemspec
+++ b/hoosegow.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/github/hoosegow'
   s.required_ruby_version = ">= 1.9.3"
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec',      '>= 2.14.1', '~> 2.14'
+  s.add_development_dependency 'rspec',      '~> 3.0.0'
   s.add_runtime_dependency     'msgpack',    '~> 1.0.0'
   s.add_runtime_dependency     'yajl-ruby',  '>= 1.1.0',  '~> 1.1'
   s.add_runtime_dependency     'docker-api', '~> 1.19'

--- a/hoosegow.gemspec
+++ b/hoosegow.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/github/hoosegow'
   s.required_ruby_version = ">= 1.9.3"
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec',      '~> 3.3.0'
+  s.add_development_dependency 'rspec',      '~> 3.9.0'
   s.add_runtime_dependency     'msgpack',    '~> 1.0.0'
   s.add_runtime_dependency     'yajl-ruby',  '>= 1.1.0',  '~> 1.1'
   s.add_runtime_dependency     'docker-api', '~> 1.19'

--- a/hoosegow.gemspec
+++ b/hoosegow.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/github/hoosegow'
   s.required_ruby_version = ">= 1.9.3"
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec',      '~> 3.0.0'
+  s.add_development_dependency 'rspec',      '~> 3.1.0'
   s.add_runtime_dependency     'msgpack',    '~> 1.0.0'
   s.add_runtime_dependency     'yajl-ruby',  '>= 1.1.0',  '~> 1.1'
   s.add_runtime_dependency     'docker-api', '~> 1.19'

--- a/spec/hoosegow_docker_spec.rb
+++ b/spec/hoosegow_docker_spec.rb
@@ -113,7 +113,7 @@ describe Hoosegow::Docker do
     let(:cb) { double("callback") }
 
     it "calls after_create" do
-      cb.should_receive(:call).with(instance_of(Hash))
+      expect(cb).to receive(:call).with(instance_of(Hash))
       docker = Hoosegow::Docker.new CONFIG.merge(:after_create => cb)
       begin
         docker.create_container CONFIG[:image_name]
@@ -124,7 +124,7 @@ describe Hoosegow::Docker do
     end
 
     it "calls after_start" do
-      cb.should_receive(:call).with(instance_of(Hash))
+      expect(cb).to receive(:call).with(instance_of(Hash))
       docker = Hoosegow::Docker.new CONFIG.merge(:after_start => cb)
       begin
         docker.create_container CONFIG[:image_name]
@@ -136,7 +136,7 @@ describe Hoosegow::Docker do
     end
 
     it "calls after_stop" do
-      cb.should_receive(:call).with(instance_of(Hash))
+      expect(cb).to receive(:call).with(instance_of(Hash))
       docker = Hoosegow::Docker.new CONFIG.merge(:after_stop => cb)
       begin
         docker.create_container CONFIG[:image_name]

--- a/spec/hoosegow_docker_spec.rb
+++ b/spec/hoosegow_docker_spec.rb
@@ -19,12 +19,12 @@ describe Hoosegow::Docker do
 
     context 'unspecified' do
       subject { described_class.new }
-      its(:volumes_for_bind) { should be_empty }
+      it { expect(subject.send(:volumes_for_bind)).to be_empty }
     end
 
     context 'empty' do
       let(:volumes) { {} }
-      its(:volumes_for_bind) { should be_empty }
+      it { expect(subject.send(:volumes_for_bind)).to be_empty }
     end
 
     context 'with volumes' do
@@ -32,10 +32,10 @@ describe Hoosegow::Docker do
         "/inside/path" => "/home/burke/data-for-container:rw",
         "/other/path" => "/etc/shared-config",
       } }
-      its(:volumes_for_bind) { should == [
+      it { expect(subject.send(:volumes_for_bind)).to eq([
         "/home/burke/data-for-container:/inside/path:rw",
         "/etc/shared-config:/other/path:ro",
-      ] }
+      ]) }
     end
   end
 
@@ -110,10 +110,10 @@ describe Hoosegow::Docker do
   end
 
   context "callbacks" do
-    let(:cb) { lambda { |info|  } }
+    let(:cb) { double("callback") }
 
     it "calls after_create" do
-      expect(cb).to receive(:call).with { |*args| args.first.is_a? Hash }
+      cb.should_receive(:call).with(instance_of(Hash))
       docker = Hoosegow::Docker.new CONFIG.merge(:after_create => cb)
       begin
         docker.create_container CONFIG[:image_name]
@@ -124,7 +124,7 @@ describe Hoosegow::Docker do
     end
 
     it "calls after_start" do
-      expect(cb).to receive(:call).with { |*args| args.first.is_a? Hash }
+      cb.should_receive(:call).with(instance_of(Hash))
       docker = Hoosegow::Docker.new CONFIG.merge(:after_start => cb)
       begin
         docker.create_container CONFIG[:image_name]
@@ -136,7 +136,7 @@ describe Hoosegow::Docker do
     end
 
     it "calls after_stop" do
-      expect(cb).to receive(:call).with { |*args| args.first.is_a? Hash }
+      cb.should_receive(:call).with(instance_of(Hash))
       docker = Hoosegow::Docker.new CONFIG.merge(:after_stop => cb)
       begin
         docker.create_container CONFIG[:image_name]

--- a/spec/hoosegow_spec.rb
+++ b/spec/hoosegow_spec.rb
@@ -17,14 +17,14 @@ describe Hoosegow do
   context "no_proxy option" do
     it "runs directly if set" do
       hoosegow = Hoosegow.new CONFIG.merge(:no_proxy => true)
-      hoosegow.stub :proxy_send => "not raboof"
-      hoosegow.render_reverse("foobar").should eq("raboof")
+      allow(hoosegow).to receive(:proxy_send).and_return("not raboof")
+      expect(hoosegow.render_reverse("foobar")).to eq("raboof")
     end
 
     it "runs via proxy if not set" do
       hoosegow = Hoosegow.new CONFIG
-      hoosegow.stub :proxy_send => "not raboof"
-      hoosegow.render_reverse("foobar").should eq("not raboof")
+      allow(hoosegow).to receive(:proxy_send).and_return("not raboof")
+      expect(hoosegow.render_reverse("foobar")).to eq("not raboof")
       hoosegow.cleanup
     end
   end
@@ -54,7 +54,7 @@ describe Hoosegow::Protocol::Proxy do
   end
 
   it "decodes a yield" do
-    block.should_receive(:call).with('a', 'b')
+    expect(block).to receive(:call).with('a', 'b')
     proxy.receive(:stdout, MessagePack.pack([:yield, ['a', 'b']]))
   end
 
@@ -83,12 +83,12 @@ describe Hoosegow::Protocol::Proxy do
   end
 
   it "decodes stdout" do
-    stdout.should_receive(:write).with('abc')
+    expect(stdout).to receive(:write).with('abc')
     proxy.receive(:stdout, MessagePack.pack([:stdout, 'abc']))
   end
 
   it "decodes stderr" do
-    stderr.should_receive(:write).with('abc')
+    expect(stderr).to receive(:write).with('abc')
     proxy.receive(:stderr, 'abc')
   end
 
@@ -103,7 +103,7 @@ end
 describe Hoosegow::Protocol::Inmate do
   it "calls appropriate render method" do
     inmate = double('inmate')
-    inmate.should_receive(:render).with('foobar').
+    expect(inmate).to receive(:render).with('foobar').
       and_yield(:a, 1).
       and_yield(:b, 2, 3).
       and_return('raboof')
@@ -143,7 +143,7 @@ describe Hoosegow::Protocol::Inmate do
     feed_stdin.write(MessagePack.pack(['render', ['foobar']]))
 
     inmate = double('inmate')
-    inmate.should_receive(:render).with('foobar').and_return('raboof')
+    expect(inmate).to receive(:render).with('foobar').and_return('raboof')
     stdout = StringIO.new
     stdout.set_encoding('BINARY')
     r,w = IO.pipe
@@ -155,7 +155,7 @@ describe Hoosegow::Protocol::Inmate do
 
   it "encodes stdout" do
     inmate = double('inmate')
-    inmate.should_receive(:render).with('foobar').and_return('raboof')
+    expect(inmate).to receive(:render).with('foobar').and_return('raboof')
 
     stdin = StringIO.new(MessagePack.pack(['render', ['foobar']]))
     stdout = StringIO.new

--- a/spec/hoosegow_spec.rb
+++ b/spec/hoosegow_spec.rb
@@ -163,8 +163,7 @@ describe Hoosegow::Protocol::Inmate do
 
     Hoosegow::Protocol::Inmate.run(:inmate => inmate, :stdin => stdin, :stdout => stdout, :intercepted => r)
 
-    encoded_stdout = MessagePack.pack([:stdout, "STDOUT from somewhere\n"])
-    encoded_return = MessagePack.pack([:return, 'raboof'])
-    expect([encoded_stdout+encoded_return, encoded_return+encoded_stdout]).to include(stdout.string)
+    output = MessagePack::Unpacker.new(StringIO.new(stdout.string)).each.to_a
+    expect(output.sort).to eq([ ["return", "raboof"], ["stdout", "STDOUT from somewhere\n"] ])
   end
 end

--- a/spec/hoosegow_spec.rb
+++ b/spec/hoosegow_spec.rb
@@ -148,7 +148,9 @@ describe Hoosegow::Protocol::Inmate do
     stdout.set_encoding('BINARY')
     r,w = IO.pipe
 
-    timeout(2) { Hoosegow::Protocol::Inmate.run(:inmate => inmate, :stdin => stdin, :stdout => stdout, :intercepted => r) }
+    Timeout.timeout(2) do
+      Hoosegow::Protocol::Inmate.run(:inmate => inmate, :stdin => stdin, :stdout => stdout, :intercepted => r)
+    end
   end
 
   it "encodes stdout" do


### PR DESCRIPTION
`rake spec` raise an error because rake doesn't have a `last_comment` field on tasks anymore, as of version 11.x or so. RSpec 3.4.4 includes a compatibility fix. RSpec 3.9 is the current version, so we may as well use it.